### PR TITLE
Future-proofing slop

### DIFF
--- a/src/unix-utils/wrappers/slop.js
+++ b/src/unix-utils/wrappers/slop.js
@@ -1,8 +1,9 @@
 import { exec } from '../utils';
 
 export default function slop() {
-  return exec(`slop`).then(res => {
-    const [x, y, width, height] = res.split('\n').map(_ => _.split('=')[1]);
+  return exec(`slop -f%g`).then(res => {
+    const [dim, x, y] = res.split('+');
+    const [width, height] = dim[0].split('x');
     return { width, height, x, y };
   });
 };


### PR DESCRIPTION
The newest slop no longer prints out `eval` formatted strings.
I didn't test this code so you probably should test this before merging, but the general idea is that you should tell slop what format you want since the default output is changing.